### PR TITLE
add key-value pairs for granular searching

### DIFF
--- a/indices/apis.js
+++ b/indices/apis.js
@@ -53,6 +53,17 @@ function getRecords () {
   })
 
   return records.map(record => {
+    record.keyValuePairs = [
+      'is:doc',
+      'is:api',
+      `api:${record.name}`,
+      `api:${record.slug}`,
+      `api:${record.fullSignature}`,
+      `doc:${record.name}`,
+      `doc:${record.slug}`,
+      `doc:${record.fullSignature}`
+    ]
+
     return Object.assign(
       {objectID: record.url.replace('https://electronjs.org/docs/api/', 'api-')},
       record

--- a/indices/apps.js
+++ b/indices/apps.js
@@ -10,6 +10,12 @@ function getRecords () {
     delete app.readmeCleaned
     delete app.readmeOriginal
 
+    app.keyValuePairs = [
+      'is:app',
+      `app:${app.name}`,
+      `app:${app.slug}`
+    ]
+
     return Object.assign(
       {objectID: `app-${app.slug}`},
       app

--- a/indices/packages.js
+++ b/indices/packages.js
@@ -16,13 +16,35 @@ function getRecords () {
       pkg.repository = pkg.repository.https_url
     }
 
+    pkg.keyValuePairs = [
+      'is:package',
+      'is:pkg',
+      `pkg:${pkg.name}`,
+      `package:${pkg.name}`
+    ]
+
+    if (Array.isArray(pkg.owners)) {
+      pkg.owners.forEach(({name}) => {
+        if (!name) return
+        pkg.keyValuePairs.push(`owner:${name}`)
+        pkg.keyValuePairs.push(`author:${name}`)
+        pkg.keyValuePairs.push(`maintainer:${name}`)
+      })
+    }
+
     // algolia doesn't search on keys, so save all dep names in a searchable array
     if (pkg.dependencies) {
       pkg.depNames = Object.keys(pkg.dependencies)
+      pkg.depNames.forEach(dep => {
+        pkg.keyValuePairs.push(`dep:${dep}`)
+      })
     }
 
     if (pkg.devDependencies) {
       pkg.devDepNames = Object.keys(pkg.devDependencies)
+      pkg.devDepNames.forEach(dep => {
+        pkg.keyValuePairs.push(`dep:${dep}`)
+      })
     }
 
     return pkg

--- a/indices/tutorials.js
+++ b/indices/tutorials.js
@@ -17,6 +17,15 @@ function getRecords () {
       if (!title && body.startsWith('Moved to')) return
       if (slug === 'README') return
 
+      const keyValuePairs = [
+        'is:doc',
+        'is:tutorial',
+        `doc:${title}`,
+        `doc:${slug}`,
+        `tutorial:${title}`,
+        `tutorial:${slug}`
+      ]
+
       const url = `https://electronjs.org/docs/tutorial/${slug}`
       return {
         objectID,
@@ -24,7 +33,8 @@ function getRecords () {
         githubUrl,
         url,
         slug,
-        body
+        body,
+        keyValuePairs
       }
     })
     .compact() // remove nulls from early returns above

--- a/lib/algolia-index.js
+++ b/lib/algolia-index.js
@@ -27,6 +27,11 @@ module.exports = class AlgoliaIndex {
         isString(record.objectID) && record.objectID.length,
         `objectID must be a string. received: ${record.objectID}, ${JSON.stringify(record)}`
       )
+
+      assert(
+        Array.isArray(record.keyValuePairs) && record.keyValuePairs.length,
+        `keyValuePairs must be a non-empty array, , ${JSON.stringify(record)}`
+      )
     })
 
     return true

--- a/test.js
+++ b/test.js
@@ -29,7 +29,8 @@ test('electron-search', t => {
   apis.forEach(api => {
     t.equal(typeof api.fullSignature, 'string', `${api.fullSignature} has a fullSignature`)
     t.equal(typeof api.name, 'string', `${api.fullSignature} has a name`)
-    // t.ok(isURL(api.url), `${api.title} has a valid URL`)
+    t.ok(api.keyValuePairs.includes('is:api'), `${api.fullSignature} has is:api key-value pair`)
+    t.ok(api.keyValuePairs.includes('is:doc'), `${api.fullSignature} has is:api key-value pair`)
   })
 
   // Tutorials
@@ -44,6 +45,8 @@ test('electron-search', t => {
     t.equal(typeof tutorial.body, 'string', `${tutorial.title} has a body`)
     t.ok(isURL(tutorial.githubUrl), `${tutorial.title} has a valid GitHub URL`)
     t.ok(isURL(tutorial.url), `${tutorial.title} has a valid website URL`)
+    t.ok(tutorial.keyValuePairs.includes('is:doc'), `${tutorial.title} has is:doc key-value pair`)
+    t.ok(tutorial.keyValuePairs.includes('is:tutorial'), `${tutorial.title} has is:tutorial key-value pair`)
   })
 
   // Packages
@@ -55,11 +58,16 @@ test('electron-search', t => {
   packages.forEach(pkg => {
     if (!pkg.name) console.log(pkg)
     t.equal(typeof pkg.name, 'string', `${pkg.name} has a name`)
+    t.ok(pkg.keyValuePairs.includes('is:pkg'), `${pkg.name} has is:pkg key-value pair`)
+    t.ok(pkg.keyValuePairs.includes('is:pkg'), `${pkg.name} has is:package key-value pair`)
     // t.ok(isURL(pkg.githubUrl), `${pkg.title} has a valid GitHub URL`)
     // t.ok(isURL(pkg.repository), `${pkg.title} has a valid repository`)
   })
 
-  // Repos
+  // TODO: Apps
+  // ----------------------------------------------------------------------
+
+  // TODO: Repos
   // ----------------------------------------------------------------------
 
   t.end()


### PR DESCRIPTION
This PR adds a bunch of key-value pairs to the index to enable more granular searches:

- `is:app`
- `is:api`
- `is:tutorial`
- `is:doc` (APIs AND tutorials)
- `is:pkg`
- `is:package`

This will be useful when we start displaying results from multiple indices in a single search.

See the diff for more pairs.

Resolves #8 

cc @MarshallOfSound @echjordan 