### PR TITLE
chore: reduce test output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1209,6 +1209,12 @@
         "string-width": "^2.0.0"
       }
     },
+    "ansi-escape": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escape/-/ansi-escape-1.1.0.tgz",
+      "integrity": "sha1-ithZ6Epp4P+Rd5aUeTqS5OjAXpk=",
+      "dev": true
+    },
     "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
@@ -2408,8 +2414,7 @@
       "version": "2.17.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
       "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -3066,12 +3071,6 @@
       "requires": {
         "dotenv": "^6.1.0"
       }
-    },
-    "duplexer": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
-      "dev": true
     },
     "duplexer2": {
       "version": "0.1.4",
@@ -12824,71 +12823,27 @@
         }
       }
     },
-    "tap-spec": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tap-spec/-/tap-spec-5.0.0.tgz",
-      "integrity": "sha512-zMDVJiE5I6Y4XGjlueGXJIX2YIkbDN44broZlnypT38Hj/czfOXrszHNNJBF/DXR8n+x6gbfSx68x04kIEHdrw==",
+    "tap-summary": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tap-summary/-/tap-summary-4.0.0.tgz",
+      "integrity": "sha1-kyFIYrpGfFCgnzeOoOXtxd0EQz0=",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
-        "duplexer": "^0.1.1",
-        "figures": "^1.4.0",
-        "lodash": "^4.17.10",
-        "pretty-ms": "^2.1.0",
-        "repeat-string": "^1.5.2",
-        "tap-out": "^2.1.0",
-        "through2": "^2.0.0"
+        "ansi-escape": "^1.0.1",
+        "commander": "^2.9.0",
+        "figures": "^2.0.0",
+        "pretty-ms": "^3.0.0",
+        "tap-out": "^2.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+        "pretty-ms": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-3.2.0.tgz",
+          "integrity": "sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "parse-ms": "^1.0.0"
           }
-        },
-        "figures": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-          "dev": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "upload": "node script/upload.js",
     "update": "script/update.sh",
     "pretest": "npm run build",
-    "test": "tape test.js | tap-spec && standard --fix",
+    "test": "tape test.js | tap-summary && standard --fix",
     "lint": "standard --fix",
     "start": "budo demo.js --live --no-debug --open --css demo.css",
     "repl": "local-repl",
@@ -38,11 +38,11 @@
     "lodash": "^4.17.10",
     "nanohtml": "^1.2.4",
     "prettier-standard": "^9.1.1",
+    "semantic-release": "^15.6.0",
     "standard": "^12.0.1",
-    "tap-spec": "^5.0.0",
+    "tap-summary": "^4.0.0",
     "tape": "^4.9.0",
-    "travis-deploy-once": "^5.0.0",
-    "semantic-release": "^15.6.0"
+    "travis-deploy-once": "^5.0.0"
   },
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "upload": "node script/upload.js",
     "update": "script/update.sh",
     "pretest": "npm run build",
-    "test": "tape test.js | tap-summary && standard --fix",
+    "test": "tape test.js | tap-summary --no-progress && standard --fix",
     "lint": "standard --fix",
     "start": "budo demo.js --live --no-debug --open --css demo.css",
     "repl": "local-repl",


### PR DESCRIPTION
This PR changes the `test` script to use `tap-summary` instead of `tap-spec` to greatly reduce the number of lines sent to the log.