### PR TITLE
chore: replace actions/bin/filter with tip-of-branch

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -26,7 +26,7 @@ action "Run tests" {
 }
 
 action "Only publish master branch" {
-  uses = "BinaryMuse/tip-of-branch@stable"
+  uses = "BinaryMuse/tip-of-branch@master"
   needs = ["Run tests"]
   args = "master"
   secrets = ["GITHUB_TOKEN"]

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -26,9 +26,10 @@ action "Run tests" {
 }
 
 action "Only publish master branch" {
-  uses = "actions/bin/filter@master"
+  uses = "BinaryMuse/tip-of-branch@stable"
   needs = ["Run tests"]
-  args = "branch master"
+  args = "master"
+  secrets = ["GITHUB_TOKEN"]
 }
 
 action "Publish via semantic-release" {


### PR DESCRIPTION
The `branch master` check from `actions/bin/filter` checks the branch that the workflow was run from, not the branch that the commit was pushed to. [BinaryMuse/tip-of-branch](https://github.com/BinaryMuse/tip-of-branch) correctly checks that the commit was pushed to `master`, was not a `delete` event, and is still at the tip of `master` when the action runs, preventing race conditions when merging multiple PRs.