### PR TITLE
fix: use config for requiring dotenv-safe

### DIFF
--- a/script/upload.js
+++ b/script/upload.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-require('dotenv-safe').load()
+require('dotenv-safe').config()
 
 const indices = require('../indices')
 


### PR DESCRIPTION
Looks like something that broken when `dotenv-safe` upped to v8