### PR TITLE
fix: use websiteUrl and urlFragment from API json

### DIFF
--- a/indices/apis.js
+++ b/indices/apis.js
@@ -7,17 +7,8 @@ const slugger = new (require('github-slugger'))()
 
 module.exports = new AlgoliaIndex('apis', getRecords())
 
-/**
- * @param {Array<String>} platform
- */
-function platformNeeded (platform) {
-  if (platform !== undefined) {
-    const platformReturn = `-${platform.join('-').toLowerCase()}`
-    if (platform.includes('(Deprecated)')) return platformReturn.replace('(deprecated)', 'deprecated')
-    return platformReturn
-  }
-
-  return ''
+function getUrlFragment (urlFragment) {
+  return urlFragment !== undefined ? urlFragment : '' 
 }
 
 function signatureNeeded (signature) {
@@ -39,7 +30,7 @@ function getRecords () {
       property.fullSignature = `${api.name}.${property.name}`
       property.tldr = getTLDR(property)
       property.slug = slugger.slug(property.fullSignature, false)
-      property.url = `https://electronjs.org/docs/api/${api.slug}#${property.slug}${platformNeeded(property.platforms)}`
+      property.url = `${api.websiteUrl}${getUrlFragment(property.urlFragment)}`
       records.push(property)
     })
 
@@ -49,7 +40,7 @@ function getRecords () {
       property.fullSignature = `${api.name}.${property.name}`
       property.tldr = getTLDR(property)
       property.slug = slugger.slug(property.fullSignature, false)
-      property.url = `https://electronjs.org/docs/api/${api.slug}#${property.slug}${platformNeeded(property.platforms)}`
+      property.url = `${api.websiteUrl}${getUrlFragment(property.urlFragment)}`
       records.push(property)
     })
 
@@ -59,7 +50,7 @@ function getRecords () {
       method.fullSignature = `${api.name}.${method.name}${signatureNeeded(method.signature)}`
       method.tldr = getTLDR(method)
       method.slug = slugger.slug(method.fullSignature, false)
-      method.url = `https://electronjs.org/docs/api/${api.slug}#${method.slug}${platformNeeded(method.platforms)}`
+      method.url = `${api.websiteUrl}${getUrlFragment(method.urlFragment)}`
       records.push(method)
     })
 
@@ -69,7 +60,7 @@ function getRecords () {
       method.fullSignature = `${api.name}.${method.name}${signatureNeeded(method.signature)}`
       method.tldr = getTLDR(method)
       method.slug = slugger.slug(method.fullSignature, false)
-      method.url = `https://electronjs.org/docs/api/${api.slug}#${method.slug}${platformNeeded(method.platforms)}`
+      method.url = `${api.websiteUrl}${getUrlFragment(method.urlFragment)}`
       records.push(method)
     })
 
@@ -79,7 +70,7 @@ function getRecords () {
       method.fullSignature = `${api.instanceName}.${method.name}${signatureNeeded(method.signature)}`
       method.tldr = getTLDR(method)
       method.slug = slugger.slug(method.fullSignature, false)
-      method.url = `https://electronjs.org/docs/api/${api.slug}#${method.slug}${platformNeeded(method.platforms)}`
+      method.url = `${api.websiteUrl}${getUrlFragment(method.urlFragment)}`
       records.push(method)
     })
 
@@ -87,7 +78,7 @@ function getRecords () {
     events.forEach(event => {
       event.apiType = 'event'
       event.fullSignature = `${api.name}.on('${event.name}')`
-      event.url = `https://electronjs.org/docs/api/${api.slug}#event-${event.name}${platformNeeded(event.platforms)}`
+      event.url = `${api.websiteUrl}${getUrlFragment(event.urlFragment)}`
       event.slug = slugger.slug(event.fullSignature, false)
       event.tldr = getTLDR(event)
       records.push(event)
@@ -97,7 +88,7 @@ function getRecords () {
     instanceEvents.forEach(event => {
       event.apiType = 'event'
       event.fullSignature = `${api.instanceName}.on('${event.name}')`
-      event.url = `https://electronjs.org/docs/api/${api.slug}#event-${event.name}${platformNeeded(event.platforms)}`
+      event.url = `${api.websiteUrl}${getUrlFragment(event.urlFragment)}`
       event.slug = slugger.slug(event.fullSignature, false)
       event.tldr = getTLDR(event)
       records.push(event)

--- a/indices/apis.js
+++ b/indices/apis.js
@@ -108,7 +108,7 @@ function getRecords () {
     ]
 
     return Object.assign(
-      { objectID: record.url.replace('https://electronjs.org/docs/api/', 'api-') + `-${record.slug}` },
+      { objectID: `${record.url.replace('https://electronjs.org/docs/api/', 'api-')}-${record.slug}` },
       record
     )
   })

--- a/indices/apis.js
+++ b/indices/apis.js
@@ -108,7 +108,7 @@ function getRecords () {
     ]
 
     return Object.assign(
-      { objectID: record.url.replace('https://electronjs.org/docs/api/', 'api-') },
+      { objectID: record.url.replace('https://electronjs.org/docs/api/', 'api-') + `-${record.slug}` },
       record
     )
   })


### PR DESCRIPTION
Successor to #226, needs `electron/docs-parser` v0.10.0 to land in `electron/electron` and for a new release to happen after that.